### PR TITLE
upgrade setup-java github action to v5

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,7 +18,7 @@ jobs:
         submodules: true
 
     - name: set up JDK 11
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '11'
         distribution: 'temurin'


### PR DESCRIPTION
Trying to solve this issue:

<div class="mt-1 tmp-mb-3 tmp-px-3">
          <div class="mx-0 mx-md-1">
            <h2 class="text-bold h4">Annotations</h2>
            <div class="color-fg-muted text-small">1 warning</div>
          </div>
        </div>
        
build                                                                                                                           Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/setup-java@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
--


